### PR TITLE
Replaced go-kit with codelingo

### DIFF
--- a/circuitbreaker/gobreaker.go
+++ b/circuitbreaker/gobreaker.go
@@ -4,7 +4,7 @@ import (
 	"github.com/sony/gobreaker"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
+	"github.com/codelingo/kit/endpoint"
 )
 
 // Gobreaker returns an endpoint.Middleware that implements the circuit

--- a/circuitbreaker/gobreaker_test.go
+++ b/circuitbreaker/gobreaker_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/sony/gobreaker"
 
-	"github.com/go-kit/kit/circuitbreaker"
+	"github.com/codelingo/kit/circuitbreaker"
 )
 
 func TestGobreaker(t *testing.T) {

--- a/circuitbreaker/handy_breaker.go
+++ b/circuitbreaker/handy_breaker.go
@@ -6,7 +6,7 @@ import (
 	"github.com/streadway/handy/breaker"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
+	"github.com/codelingo/kit/endpoint"
 )
 
 // HandyBreaker returns an endpoint.Middleware that implements the circuit

--- a/circuitbreaker/handy_breaker_test.go
+++ b/circuitbreaker/handy_breaker_test.go
@@ -5,7 +5,7 @@ import (
 
 	handybreaker "github.com/streadway/handy/breaker"
 
-	"github.com/go-kit/kit/circuitbreaker"
+	"github.com/codelingo/kit/circuitbreaker"
 )
 
 func TestHandyBreaker(t *testing.T) {

--- a/circuitbreaker/hystrix.go
+++ b/circuitbreaker/hystrix.go
@@ -4,7 +4,7 @@ import (
 	"github.com/afex/hystrix-go/hystrix"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
+	"github.com/codelingo/kit/endpoint"
 )
 
 // Hystrix returns an endpoint.Middleware that implements the circuit

--- a/circuitbreaker/hystrix_test.go
+++ b/circuitbreaker/hystrix_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/afex/hystrix-go/hystrix"
 
-	"github.com/go-kit/kit/circuitbreaker"
+	"github.com/codelingo/kit/circuitbreaker"
 )
 
 func TestHystrix(t *testing.T) {

--- a/circuitbreaker/util_test.go
+++ b/circuitbreaker/util_test.go
@@ -10,7 +10,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
+	"github.com/codelingo/kit/endpoint"
 )
 
 func testFailingEndpoint(

--- a/endpoint/endpoint_example_test.go
+++ b/endpoint/endpoint_example_test.go
@@ -5,7 +5,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
+	"github.com/codelingo/kit/endpoint"
 )
 
 func ExampleChain() {

--- a/examples/addsvc/client/grpc/client.go
+++ b/examples/addsvc/client/grpc/client.go
@@ -9,14 +9,14 @@ import (
 	"github.com/sony/gobreaker"
 	"google.golang.org/grpc"
 
-	"github.com/go-kit/kit/circuitbreaker"
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/examples/addsvc"
-	"github.com/go-kit/kit/examples/addsvc/pb"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/ratelimit"
-	"github.com/go-kit/kit/tracing/opentracing"
-	grpctransport "github.com/go-kit/kit/transport/grpc"
+	"github.com/codelingo/kit/circuitbreaker"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/examples/addsvc"
+	"github.com/codelingo/kit/examples/addsvc/pb"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/ratelimit"
+	"github.com/codelingo/kit/tracing/opentracing"
+	grpctransport "github.com/codelingo/kit/transport/grpc"
 )
 
 // New returns an AddService backed by a gRPC client connection. It is the

--- a/examples/addsvc/client/http/client.go
+++ b/examples/addsvc/client/http/client.go
@@ -10,13 +10,13 @@ import (
 	stdopentracing "github.com/opentracing/opentracing-go"
 	"github.com/sony/gobreaker"
 
-	"github.com/go-kit/kit/circuitbreaker"
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/examples/addsvc"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/ratelimit"
-	"github.com/go-kit/kit/tracing/opentracing"
-	httptransport "github.com/go-kit/kit/transport/http"
+	"github.com/codelingo/kit/circuitbreaker"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/examples/addsvc"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/ratelimit"
+	"github.com/codelingo/kit/tracing/opentracing"
+	httptransport "github.com/codelingo/kit/transport/http"
 )
 
 // New returns an AddService backed by an HTTP server living at the remote

--- a/examples/addsvc/client/thrift/client.go
+++ b/examples/addsvc/client/thrift/client.go
@@ -7,11 +7,11 @@ import (
 	jujuratelimit "github.com/juju/ratelimit"
 	"github.com/sony/gobreaker"
 
-	"github.com/go-kit/kit/circuitbreaker"
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/examples/addsvc"
-	thriftadd "github.com/go-kit/kit/examples/addsvc/thrift/gen-go/addsvc"
-	"github.com/go-kit/kit/ratelimit"
+	"github.com/codelingo/kit/circuitbreaker"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/examples/addsvc"
+	thriftadd "github.com/codelingo/kit/examples/addsvc/thrift/gen-go/addsvc"
+	"github.com/codelingo/kit/ratelimit"
 )
 
 // New returns an AddService backed by a Thrift server described by the provided

--- a/examples/addsvc/cmd/addcli/main.go
+++ b/examples/addsvc/cmd/addcli/main.go
@@ -17,12 +17,12 @@ import (
 	"sourcegraph.com/sourcegraph/appdash"
 	appdashot "sourcegraph.com/sourcegraph/appdash/opentracing"
 
-	"github.com/go-kit/kit/examples/addsvc"
-	grpcclient "github.com/go-kit/kit/examples/addsvc/client/grpc"
-	httpclient "github.com/go-kit/kit/examples/addsvc/client/http"
-	thriftclient "github.com/go-kit/kit/examples/addsvc/client/thrift"
-	thriftadd "github.com/go-kit/kit/examples/addsvc/thrift/gen-go/addsvc"
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/examples/addsvc"
+	grpcclient "github.com/codelingo/kit/examples/addsvc/client/grpc"
+	httpclient "github.com/codelingo/kit/examples/addsvc/client/http"
+	thriftclient "github.com/codelingo/kit/examples/addsvc/client/thrift"
+	thriftadd "github.com/codelingo/kit/examples/addsvc/thrift/gen-go/addsvc"
+	"github.com/codelingo/kit/log"
 )
 
 func main() {

--- a/examples/addsvc/cmd/addsvc/main.go
+++ b/examples/addsvc/cmd/addsvc/main.go
@@ -21,14 +21,14 @@ import (
 	"sourcegraph.com/sourcegraph/appdash"
 	appdashot "sourcegraph.com/sourcegraph/appdash/opentracing"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/examples/addsvc"
-	"github.com/go-kit/kit/examples/addsvc/pb"
-	thriftadd "github.com/go-kit/kit/examples/addsvc/thrift/gen-go/addsvc"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/prometheus"
-	"github.com/go-kit/kit/tracing/opentracing"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/examples/addsvc"
+	"github.com/codelingo/kit/examples/addsvc/pb"
+	thriftadd "github.com/codelingo/kit/examples/addsvc/thrift/gen-go/addsvc"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/metrics/prometheus"
+	"github.com/codelingo/kit/tracing/opentracing"
 )
 
 func main() {

--- a/examples/addsvc/endpoints.go
+++ b/examples/addsvc/endpoints.go
@@ -11,9 +11,9 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/metrics"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/metrics"
 )
 
 // Endpoints collects all of the endpoints that compose an add service. It's

--- a/examples/addsvc/service.go
+++ b/examples/addsvc/service.go
@@ -9,8 +9,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/metrics"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/metrics"
 )
 
 // Service describes a service that adds things together.

--- a/examples/addsvc/thrift/gen-go/addsvc/add_service-remote/add_service-remote.go
+++ b/examples/addsvc/thrift/gen-go/addsvc/add_service-remote/add_service-remote.go
@@ -7,7 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/apache/thrift/lib/go/thrift"
-	"github.com/go-kit/kit/examples/addsvc/thrift/gen-go/addsvc"
+	"github.com/codelingo/kit/examples/addsvc/thrift/gen-go/addsvc"
 	"math"
 	"net"
 	"net/url"

--- a/examples/addsvc/transport_grpc.go
+++ b/examples/addsvc/transport_grpc.go
@@ -7,10 +7,10 @@ import (
 	stdopentracing "github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/examples/addsvc/pb"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/tracing/opentracing"
-	grpctransport "github.com/go-kit/kit/transport/grpc"
+	"github.com/codelingo/kit/examples/addsvc/pb"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/tracing/opentracing"
+	grpctransport "github.com/codelingo/kit/transport/grpc"
 )
 
 // MakeGRPCServer makes a set of endpoints available as a gRPC AddServer.

--- a/examples/addsvc/transport_http.go
+++ b/examples/addsvc/transport_http.go
@@ -13,9 +13,9 @@ import (
 	stdopentracing "github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/tracing/opentracing"
-	httptransport "github.com/go-kit/kit/transport/http"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/tracing/opentracing"
+	httptransport "github.com/codelingo/kit/transport/http"
 )
 
 // MakeHTTPHandler returns a handler that makes a set of endpoints available

--- a/examples/addsvc/transport_thrift.go
+++ b/examples/addsvc/transport_thrift.go
@@ -9,8 +9,8 @@ package addsvc
 import (
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
-	thriftadd "github.com/go-kit/kit/examples/addsvc/thrift/gen-go/addsvc"
+	"github.com/codelingo/kit/endpoint"
+	thriftadd "github.com/codelingo/kit/examples/addsvc/thrift/gen-go/addsvc"
 )
 
 // MakeThriftHandler makes a set of endpoints available as a Thrift service.

--- a/examples/apigateway/main.go
+++ b/examples/apigateway/main.go
@@ -20,14 +20,14 @@ import (
 	stdopentracing "github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/examples/addsvc"
-	addsvcgrpcclient "github.com/go-kit/kit/examples/addsvc/client/grpc"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/sd"
-	consulsd "github.com/go-kit/kit/sd/consul"
-	"github.com/go-kit/kit/sd/lb"
-	httptransport "github.com/go-kit/kit/transport/http"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/examples/addsvc"
+	addsvcgrpcclient "github.com/codelingo/kit/examples/addsvc/client/grpc"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/sd"
+	consulsd "github.com/codelingo/kit/sd/consul"
+	"github.com/codelingo/kit/sd/lb"
+	httptransport "github.com/codelingo/kit/transport/http"
 	"google.golang.org/grpc"
 )
 

--- a/examples/profilesvc/client/client.go
+++ b/examples/profilesvc/client/client.go
@@ -9,12 +9,12 @@ import (
 
 	consulapi "github.com/hashicorp/consul/api"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/examples/profilesvc"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/sd"
-	"github.com/go-kit/kit/sd/consul"
-	"github.com/go-kit/kit/sd/lb"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/examples/profilesvc"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/sd"
+	"github.com/codelingo/kit/sd/consul"
+	"github.com/codelingo/kit/sd/lb"
 )
 
 // New returns a service that's load-balanced over instances of profilesvc found

--- a/examples/profilesvc/cmd/profilesvc/main.go
+++ b/examples/profilesvc/cmd/profilesvc/main.go
@@ -10,8 +10,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/examples/profilesvc"
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/examples/profilesvc"
+	"github.com/codelingo/kit/log"
 )
 
 func main() {

--- a/examples/profilesvc/endpoints.go
+++ b/examples/profilesvc/endpoints.go
@@ -6,8 +6,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
-	httptransport "github.com/go-kit/kit/transport/http"
+	"github.com/codelingo/kit/endpoint"
+	httptransport "github.com/codelingo/kit/transport/http"
 )
 
 // Endpoints collects all of the endpoints that compose a profile service. It's

--- a/examples/profilesvc/middlewares.go
+++ b/examples/profilesvc/middlewares.go
@@ -5,7 +5,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 // Middleware describes a service (as opposed to endpoint) middleware.

--- a/examples/profilesvc/transport.go
+++ b/examples/profilesvc/transport.go
@@ -14,8 +14,8 @@ import (
 	"github.com/gorilla/mux"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/log"
-	httptransport "github.com/go-kit/kit/transport/http"
+	"github.com/codelingo/kit/log"
+	httptransport "github.com/codelingo/kit/transport/http"
 )
 
 var (

--- a/examples/shipping/booking/endpoint.go
+++ b/examples/shipping/booking/endpoint.go
@@ -5,9 +5,9 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/examples/shipping/cargo"
-	"github.com/go-kit/kit/examples/shipping/location"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/examples/shipping/cargo"
+	"github.com/codelingo/kit/examples/shipping/location"
 )
 
 type bookCargoRequest struct {

--- a/examples/shipping/booking/instrumenting.go
+++ b/examples/shipping/booking/instrumenting.go
@@ -3,10 +3,10 @@ package booking
 import (
 	"time"
 
-	"github.com/go-kit/kit/metrics"
+	"github.com/codelingo/kit/metrics"
 
-	"github.com/go-kit/kit/examples/shipping/cargo"
-	"github.com/go-kit/kit/examples/shipping/location"
+	"github.com/codelingo/kit/examples/shipping/cargo"
+	"github.com/codelingo/kit/examples/shipping/location"
 )
 
 type instrumentingService struct {

--- a/examples/shipping/booking/logging.go
+++ b/examples/shipping/booking/logging.go
@@ -3,9 +3,9 @@ package booking
 import (
 	"time"
 
-	"github.com/go-kit/kit/examples/shipping/cargo"
-	"github.com/go-kit/kit/examples/shipping/location"
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/examples/shipping/cargo"
+	"github.com/codelingo/kit/examples/shipping/location"
+	"github.com/codelingo/kit/log"
 )
 
 type loggingService struct {

--- a/examples/shipping/booking/service.go
+++ b/examples/shipping/booking/service.go
@@ -6,9 +6,9 @@ import (
 	"errors"
 	"time"
 
-	"github.com/go-kit/kit/examples/shipping/cargo"
-	"github.com/go-kit/kit/examples/shipping/location"
-	"github.com/go-kit/kit/examples/shipping/routing"
+	"github.com/codelingo/kit/examples/shipping/cargo"
+	"github.com/codelingo/kit/examples/shipping/location"
+	"github.com/codelingo/kit/examples/shipping/routing"
 )
 
 // ErrInvalidArgument is returned when one or more arguments are invalid.

--- a/examples/shipping/booking/transport.go
+++ b/examples/shipping/booking/transport.go
@@ -9,10 +9,10 @@ import (
 	"github.com/gorilla/mux"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/examples/shipping/cargo"
-	"github.com/go-kit/kit/examples/shipping/location"
-	kitlog "github.com/go-kit/kit/log"
-	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/codelingo/kit/examples/shipping/cargo"
+	"github.com/codelingo/kit/examples/shipping/location"
+	kitlog "github.com/codelingo/kit/log"
+	kithttp "github.com/codelingo/kit/transport/http"
 )
 
 // MakeHandler returns a handler for the booking service.

--- a/examples/shipping/cargo/cargo.go
+++ b/examples/shipping/cargo/cargo.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/pborman/uuid"
 
-	"github.com/go-kit/kit/examples/shipping/location"
+	"github.com/codelingo/kit/examples/shipping/location"
 )
 
 // TrackingID uniquely identifies a particular cargo.

--- a/examples/shipping/cargo/delivery.go
+++ b/examples/shipping/cargo/delivery.go
@@ -3,8 +3,8 @@ package cargo
 import (
 	"time"
 
-	"github.com/go-kit/kit/examples/shipping/location"
-	"github.com/go-kit/kit/examples/shipping/voyage"
+	"github.com/codelingo/kit/examples/shipping/location"
+	"github.com/codelingo/kit/examples/shipping/voyage"
 )
 
 // Delivery is the actual transportation of the cargo, as opposed to the

--- a/examples/shipping/cargo/handling.go
+++ b/examples/shipping/cargo/handling.go
@@ -12,8 +12,8 @@ import (
 	"errors"
 	"time"
 
-	"github.com/go-kit/kit/examples/shipping/location"
-	"github.com/go-kit/kit/examples/shipping/voyage"
+	"github.com/codelingo/kit/examples/shipping/location"
+	"github.com/codelingo/kit/examples/shipping/voyage"
 )
 
 // HandlingActivity represents how and where a cargo can be handled, and can

--- a/examples/shipping/cargo/itinerary.go
+++ b/examples/shipping/cargo/itinerary.go
@@ -3,8 +3,8 @@ package cargo
 import (
 	"time"
 
-	"github.com/go-kit/kit/examples/shipping/location"
-	"github.com/go-kit/kit/examples/shipping/voyage"
+	"github.com/codelingo/kit/examples/shipping/location"
+	"github.com/codelingo/kit/examples/shipping/voyage"
 )
 
 // Leg describes the transportation between two locations on a voyage.

--- a/examples/shipping/handling/endpoint.go
+++ b/examples/shipping/handling/endpoint.go
@@ -5,10 +5,10 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/examples/shipping/cargo"
-	"github.com/go-kit/kit/examples/shipping/location"
-	"github.com/go-kit/kit/examples/shipping/voyage"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/examples/shipping/cargo"
+	"github.com/codelingo/kit/examples/shipping/location"
+	"github.com/codelingo/kit/examples/shipping/voyage"
 )
 
 type registerIncidentRequest struct {

--- a/examples/shipping/handling/instrumenting.go
+++ b/examples/shipping/handling/instrumenting.go
@@ -3,11 +3,11 @@ package handling
 import (
 	"time"
 
-	"github.com/go-kit/kit/metrics"
+	"github.com/codelingo/kit/metrics"
 
-	"github.com/go-kit/kit/examples/shipping/cargo"
-	"github.com/go-kit/kit/examples/shipping/location"
-	"github.com/go-kit/kit/examples/shipping/voyage"
+	"github.com/codelingo/kit/examples/shipping/cargo"
+	"github.com/codelingo/kit/examples/shipping/location"
+	"github.com/codelingo/kit/examples/shipping/voyage"
 )
 
 type instrumentingService struct {

--- a/examples/shipping/handling/logging.go
+++ b/examples/shipping/handling/logging.go
@@ -3,10 +3,10 @@ package handling
 import (
 	"time"
 
-	"github.com/go-kit/kit/examples/shipping/cargo"
-	"github.com/go-kit/kit/examples/shipping/location"
-	"github.com/go-kit/kit/examples/shipping/voyage"
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/examples/shipping/cargo"
+	"github.com/codelingo/kit/examples/shipping/location"
+	"github.com/codelingo/kit/examples/shipping/voyage"
+	"github.com/codelingo/kit/log"
 )
 
 type loggingService struct {

--- a/examples/shipping/handling/service.go
+++ b/examples/shipping/handling/service.go
@@ -6,10 +6,10 @@ import (
 	"errors"
 	"time"
 
-	"github.com/go-kit/kit/examples/shipping/cargo"
-	"github.com/go-kit/kit/examples/shipping/inspection"
-	"github.com/go-kit/kit/examples/shipping/location"
-	"github.com/go-kit/kit/examples/shipping/voyage"
+	"github.com/codelingo/kit/examples/shipping/cargo"
+	"github.com/codelingo/kit/examples/shipping/inspection"
+	"github.com/codelingo/kit/examples/shipping/location"
+	"github.com/codelingo/kit/examples/shipping/voyage"
 )
 
 // ErrInvalidArgument is returned when one or more arguments are invalid.

--- a/examples/shipping/handling/transport.go
+++ b/examples/shipping/handling/transport.go
@@ -8,11 +8,11 @@ import (
 	"github.com/gorilla/mux"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/examples/shipping/cargo"
-	"github.com/go-kit/kit/examples/shipping/location"
-	"github.com/go-kit/kit/examples/shipping/voyage"
-	kitlog "github.com/go-kit/kit/log"
-	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/codelingo/kit/examples/shipping/cargo"
+	"github.com/codelingo/kit/examples/shipping/location"
+	"github.com/codelingo/kit/examples/shipping/voyage"
+	kitlog "github.com/codelingo/kit/log"
+	kithttp "github.com/codelingo/kit/transport/http"
 )
 
 // MakeHandler returns a handler for the handling service.

--- a/examples/shipping/inspection/inspection.go
+++ b/examples/shipping/inspection/inspection.go
@@ -1,7 +1,7 @@
 // Package inspection provides means to inspect cargos.
 package inspection
 
-import "github.com/go-kit/kit/examples/shipping/cargo"
+import "github.com/codelingo/kit/examples/shipping/cargo"
 
 // EventHandler provides means of subscribing to inspection events.
 type EventHandler interface {

--- a/examples/shipping/main.go
+++ b/examples/shipping/main.go
@@ -13,17 +13,17 @@ import (
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/log"
-	kitprometheus "github.com/go-kit/kit/metrics/prometheus"
+	"github.com/codelingo/kit/log"
+	kitprometheus "github.com/codelingo/kit/metrics/prometheus"
 
-	"github.com/go-kit/kit/examples/shipping/booking"
-	"github.com/go-kit/kit/examples/shipping/cargo"
-	"github.com/go-kit/kit/examples/shipping/handling"
-	"github.com/go-kit/kit/examples/shipping/inspection"
-	"github.com/go-kit/kit/examples/shipping/location"
-	"github.com/go-kit/kit/examples/shipping/repository"
-	"github.com/go-kit/kit/examples/shipping/routing"
-	"github.com/go-kit/kit/examples/shipping/tracking"
+	"github.com/codelingo/kit/examples/shipping/booking"
+	"github.com/codelingo/kit/examples/shipping/cargo"
+	"github.com/codelingo/kit/examples/shipping/handling"
+	"github.com/codelingo/kit/examples/shipping/inspection"
+	"github.com/codelingo/kit/examples/shipping/location"
+	"github.com/codelingo/kit/examples/shipping/repository"
+	"github.com/codelingo/kit/examples/shipping/routing"
+	"github.com/codelingo/kit/examples/shipping/tracking"
 )
 
 const (

--- a/examples/shipping/repository/repositories.go
+++ b/examples/shipping/repository/repositories.go
@@ -4,9 +4,9 @@ package repository
 import (
 	"sync"
 
-	"github.com/go-kit/kit/examples/shipping/cargo"
-	"github.com/go-kit/kit/examples/shipping/location"
-	"github.com/go-kit/kit/examples/shipping/voyage"
+	"github.com/codelingo/kit/examples/shipping/cargo"
+	"github.com/codelingo/kit/examples/shipping/location"
+	"github.com/codelingo/kit/examples/shipping/voyage"
 )
 
 type cargoRepository struct {

--- a/examples/shipping/routing/proxying.go
+++ b/examples/shipping/routing/proxying.go
@@ -8,12 +8,12 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/circuitbreaker"
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/examples/shipping/cargo"
-	"github.com/go-kit/kit/examples/shipping/location"
-	"github.com/go-kit/kit/examples/shipping/voyage"
-	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/codelingo/kit/circuitbreaker"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/examples/shipping/cargo"
+	"github.com/codelingo/kit/examples/shipping/location"
+	"github.com/codelingo/kit/examples/shipping/voyage"
+	kithttp "github.com/codelingo/kit/transport/http"
 )
 
 type proxyService struct {

--- a/examples/shipping/routing/routing.go
+++ b/examples/shipping/routing/routing.go
@@ -3,7 +3,7 @@
 // bounded context.
 package routing
 
-import "github.com/go-kit/kit/examples/shipping/cargo"
+import "github.com/codelingo/kit/examples/shipping/cargo"
 
 // Service provides access to an external routing service.
 type Service interface {

--- a/examples/shipping/tracking/endpoint.go
+++ b/examples/shipping/tracking/endpoint.go
@@ -3,7 +3,7 @@ package tracking
 import (
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
+	"github.com/codelingo/kit/endpoint"
 )
 
 type trackCargoRequest struct {

--- a/examples/shipping/tracking/instrumenting.go
+++ b/examples/shipping/tracking/instrumenting.go
@@ -3,7 +3,7 @@ package tracking
 import (
 	"time"
 
-	"github.com/go-kit/kit/metrics"
+	"github.com/codelingo/kit/metrics"
 )
 
 type instrumentingService struct {

--- a/examples/shipping/tracking/logging.go
+++ b/examples/shipping/tracking/logging.go
@@ -3,7 +3,7 @@ package tracking
 import (
 	"time"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 type loggingService struct {

--- a/examples/shipping/tracking/service.go
+++ b/examples/shipping/tracking/service.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-kit/kit/examples/shipping/cargo"
+	"github.com/codelingo/kit/examples/shipping/cargo"
 )
 
 // ErrInvalidArgument is returned when one or more arguments are invalid.

--- a/examples/shipping/tracking/transport.go
+++ b/examples/shipping/tracking/transport.go
@@ -8,9 +8,9 @@ import (
 	"github.com/gorilla/mux"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/examples/shipping/cargo"
-	kitlog "github.com/go-kit/kit/log"
-	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/codelingo/kit/examples/shipping/cargo"
+	kitlog "github.com/codelingo/kit/log"
+	kithttp "github.com/codelingo/kit/transport/http"
 )
 
 // MakeHandler returns a handler for the tracking service.

--- a/examples/shipping/voyage/sample_voyages.go
+++ b/examples/shipping/voyage/sample_voyages.go
@@ -1,6 +1,6 @@
 package voyage
 
-import "github.com/go-kit/kit/examples/shipping/location"
+import "github.com/codelingo/kit/examples/shipping/location"
 
 // A set of sample voyages.
 var (

--- a/examples/shipping/voyage/voyage.go
+++ b/examples/shipping/voyage/voyage.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/go-kit/kit/examples/shipping/location"
+	"github.com/codelingo/kit/examples/shipping/location"
 )
 
 // Number uniquely identifies a particular Voyage.

--- a/examples/stringsvc1/main.go
+++ b/examples/stringsvc1/main.go
@@ -9,8 +9,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
-	httptransport "github.com/go-kit/kit/transport/http"
+	"github.com/codelingo/kit/endpoint"
+	httptransport "github.com/codelingo/kit/transport/http"
 )
 
 // StringService provides operations on strings.

--- a/examples/stringsvc2/instrumenting.go
+++ b/examples/stringsvc2/instrumenting.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-kit/kit/metrics"
+	"github.com/codelingo/kit/metrics"
 )
 
 type instrumentingMiddleware struct {

--- a/examples/stringsvc2/logging.go
+++ b/examples/stringsvc2/logging.go
@@ -3,7 +3,7 @@ package main
 import (
 	"time"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 type loggingMiddleware struct {

--- a/examples/stringsvc2/main.go
+++ b/examples/stringsvc2/main.go
@@ -7,9 +7,9 @@ import (
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/log"
-	kitprometheus "github.com/go-kit/kit/metrics/prometheus"
-	httptransport "github.com/go-kit/kit/transport/http"
+	"github.com/codelingo/kit/log"
+	kitprometheus "github.com/codelingo/kit/metrics/prometheus"
+	httptransport "github.com/codelingo/kit/transport/http"
 )
 
 func main() {

--- a/examples/stringsvc2/transport.go
+++ b/examples/stringsvc2/transport.go
@@ -6,7 +6,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
+	"github.com/codelingo/kit/endpoint"
 )
 
 func makeUppercaseEndpoint(svc StringService) endpoint.Endpoint {

--- a/examples/stringsvc3/instrumenting.go
+++ b/examples/stringsvc3/instrumenting.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-kit/kit/metrics"
+	"github.com/codelingo/kit/metrics"
 )
 
 func instrumentingMiddleware(

--- a/examples/stringsvc3/logging.go
+++ b/examples/stringsvc3/logging.go
@@ -3,7 +3,7 @@ package main
 import (
 	"time"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 func loggingMiddleware(logger log.Logger) ServiceMiddleware {

--- a/examples/stringsvc3/main.go
+++ b/examples/stringsvc3/main.go
@@ -8,9 +8,9 @@ import (
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/log"
-	kitprometheus "github.com/go-kit/kit/metrics/prometheus"
-	httptransport "github.com/go-kit/kit/transport/http"
+	"github.com/codelingo/kit/log"
+	kitprometheus "github.com/codelingo/kit/metrics/prometheus"
+	httptransport "github.com/codelingo/kit/transport/http"
 )
 
 func main() {

--- a/examples/stringsvc3/proxying.go
+++ b/examples/stringsvc3/proxying.go
@@ -11,13 +11,13 @@ import (
 	"github.com/sony/gobreaker"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/circuitbreaker"
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/ratelimit"
-	"github.com/go-kit/kit/sd"
-	"github.com/go-kit/kit/sd/lb"
-	httptransport "github.com/go-kit/kit/transport/http"
+	"github.com/codelingo/kit/circuitbreaker"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/ratelimit"
+	"github.com/codelingo/kit/sd"
+	"github.com/codelingo/kit/sd/lb"
+	httptransport "github.com/codelingo/kit/transport/http"
 )
 
 func proxyingMiddleware(instances string, ctx context.Context, logger log.Logger) ServiceMiddleware {

--- a/examples/stringsvc3/transport.go
+++ b/examples/stringsvc3/transport.go
@@ -8,7 +8,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
+	"github.com/codelingo/kit/endpoint"
 )
 
 func makeUppercaseEndpoint(svc StringService) endpoint.Endpoint {

--- a/log/README.md
+++ b/log/README.md
@@ -64,7 +64,7 @@ Redirect stdlib logger to Go kit logger.
 import (
 	"os"
 	stdlog "log"
-	kitlog "github.com/go-kit/kit/log"
+	kitlog "github.com/codelingo/kit/log"
 )
 
 func main() {

--- a/log/benchmark_test.go
+++ b/log/benchmark_test.go
@@ -3,7 +3,7 @@ package log_test
 import (
 	"testing"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 func benchmarkRunner(b *testing.B, logger log.Logger, f func(log.Logger)) {

--- a/log/concurrency_test.go
+++ b/log/concurrency_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 // These test are designed to be run with the race detector.

--- a/log/example_test.go
+++ b/log/example_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 func Example_basic() {

--- a/log/experimental_level/benchmark_test.go
+++ b/log/experimental_level/benchmark_test.go
@@ -4,8 +4,8 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/experimental_level"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/log/experimental_level"
 )
 
 func BenchmarkNopBaseline(b *testing.B) {

--- a/log/experimental_level/level.go
+++ b/log/experimental_level/level.go
@@ -1,7 +1,7 @@
 package level
 
 import (
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 var (

--- a/log/experimental_level/level_test.go
+++ b/log/experimental_level/level_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/experimental_level"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/log/experimental_level"
 )
 
 func TestVariousLevels(t *testing.T) {

--- a/log/json_logger_test.go
+++ b/log/json_logger_test.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 func TestJSONLoggerCaller(t *testing.T) {

--- a/log/levels/levels.go
+++ b/log/levels/levels.go
@@ -1,6 +1,6 @@
 package levels
 
-import "github.com/go-kit/kit/log"
+import "github.com/codelingo/kit/log"
 
 // Levels provides a leveled logging wrapper around a logger. It has five
 // levels: debug, info, warning (warn), error, and critical (crit). If you

--- a/log/levels/levels_test.go
+++ b/log/levels/levels_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/levels"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/log/levels"
 )
 
 func TestDefaultLevels(t *testing.T) {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 	"github.com/go-stack/stack"
 )
 

--- a/log/logfmt_logger_test.go
+++ b/log/logfmt_logger_test.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 	"github.com/go-logfmt/logfmt"
 )
 

--- a/log/nop_logger_test.go
+++ b/log/nop_logger_test.go
@@ -3,7 +3,7 @@ package log_test
 import (
 	"testing"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 func TestNopLogger(t *testing.T) {

--- a/log/sync_test.go
+++ b/log/sync_test.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 func TestSwapLogger(t *testing.T) {

--- a/log/term/colorlogger.go
+++ b/log/term/colorlogger.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 // Color represents an ANSI color. The zero value is Default.

--- a/log/term/colorlogger_test.go
+++ b/log/term/colorlogger_test.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/term"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/log/term"
 )
 
 func TestColorLogger(t *testing.T) {

--- a/log/term/example_test.go
+++ b/log/term/example_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"os"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/term"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/log/term"
 )
 
 func ExampleNewLogger_redErrors() {

--- a/log/term/term.go
+++ b/log/term/term.go
@@ -4,7 +4,7 @@ package term
 import (
 	"io"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 // NewLogger returns a Logger that takes advantage of terminal features if

--- a/log/value_test.go
+++ b/log/value_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 func TestValueBinding(t *testing.T) {

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -24,8 +24,8 @@ A simple counter, exported via expvar.
 
 ```go
 import (
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/expvar"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/metrics/expvar"
 )
 
 func main() {
@@ -44,8 +44,8 @@ import (
 
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/prometheus"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/metrics/prometheus"
 )
 
 func main() {
@@ -73,8 +73,8 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/statsd"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/metrics/statsd"
 )
 
 func main() {

--- a/metrics/circonus/circonus.go
+++ b/metrics/circonus/circonus.go
@@ -4,7 +4,7 @@ package circonus
 import (
 	"github.com/circonus-labs/circonus-gometrics"
 
-	"github.com/go-kit/kit/metrics"
+	"github.com/codelingo/kit/metrics"
 )
 
 // Circonus wraps a CirconusMetrics object and provides constructors for each of

--- a/metrics/circonus/circonus_test.go
+++ b/metrics/circonus/circonus_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/circonus-labs/circonus-gometrics"
 	"github.com/circonus-labs/circonus-gometrics/checkmgr"
 
-	"github.com/go-kit/kit/metrics/generic"
-	"github.com/go-kit/kit/metrics/teststat"
+	"github.com/codelingo/kit/metrics/generic"
+	"github.com/codelingo/kit/metrics/teststat"
 )
 
 func TestCounter(t *testing.T) {

--- a/metrics/discard/discard.go
+++ b/metrics/discard/discard.go
@@ -1,7 +1,7 @@
 // Package discard provides a no-op metrics backend.
 package discard
 
-import "github.com/go-kit/kit/metrics"
+import "github.com/codelingo/kit/metrics"
 
 type counter struct{}
 

--- a/metrics/dogstatsd/dogstatsd.go
+++ b/metrics/dogstatsd/dogstatsd.go
@@ -16,11 +16,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/internal/lv"
-	"github.com/go-kit/kit/metrics/internal/ratemap"
-	"github.com/go-kit/kit/util/conn"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/metrics/internal/lv"
+	"github.com/codelingo/kit/metrics/internal/ratemap"
+	"github.com/codelingo/kit/util/conn"
 )
 
 // Dogstatsd receives metrics observations and forwards them to a DogStatsD

--- a/metrics/dogstatsd/dogstatsd_test.go
+++ b/metrics/dogstatsd/dogstatsd_test.go
@@ -3,8 +3,8 @@ package dogstatsd
 import (
 	"testing"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/metrics/teststat"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/metrics/teststat"
 )
 
 func TestCounter(t *testing.T) {

--- a/metrics/dogstatsd/emitter.go
+++ b/metrics/dogstatsd/emitter.go
@@ -6,9 +6,9 @@ import (
 	"net"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/util/conn"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/util/conn"
 )
 
 // Emitter is a struct to manage connections and orchestrate the emission of

--- a/metrics/expvar/expvar.go
+++ b/metrics/expvar/expvar.go
@@ -6,8 +6,8 @@ import (
 	"expvar"
 	"sync"
 
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/generic"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/metrics/generic"
 )
 
 // Counter implements the counter metric with an expvar float.

--- a/metrics/expvar/expvar_test.go
+++ b/metrics/expvar/expvar_test.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/go-kit/kit/metrics/teststat"
+	"github.com/codelingo/kit/metrics/teststat"
 )
 
 func TestCounter(t *testing.T) {

--- a/metrics/generic/generic.go
+++ b/metrics/generic/generic.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/VividCortex/gohistogram"
 
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/internal/lv"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/metrics/internal/lv"
 )
 
 // Counter is an in-memory implementation of a Counter.

--- a/metrics/generic/generic_test.go
+++ b/metrics/generic/generic_test.go
@@ -9,8 +9,8 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/go-kit/kit/metrics/generic"
-	"github.com/go-kit/kit/metrics/teststat"
+	"github.com/codelingo/kit/metrics/generic"
+	"github.com/codelingo/kit/metrics/teststat"
 )
 
 func TestCounter(t *testing.T) {

--- a/metrics/graphite/emitter.go
+++ b/metrics/graphite/emitter.go
@@ -8,9 +8,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/util/conn"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/util/conn"
 )
 
 // Emitter is a struct to manage connections and orchestrate the emission of

--- a/metrics/graphite/graphite.go
+++ b/metrics/graphite/graphite.go
@@ -13,10 +13,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/generic"
-	"github.com/go-kit/kit/util/conn"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/metrics/generic"
+	"github.com/codelingo/kit/util/conn"
 )
 
 // Graphite receives metrics observations and forwards them to a Graphite server.

--- a/metrics/graphite/graphite_test.go
+++ b/metrics/graphite/graphite_test.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/metrics/teststat"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/metrics/teststat"
 )
 
 func TestCounter(t *testing.T) {

--- a/metrics/influx/example_test.go
+++ b/metrics/influx/example_test.go
@@ -6,7 +6,7 @@ import (
 
 	influxdb "github.com/influxdata/influxdb/client/v2"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 func ExampleCounter() {

--- a/metrics/influx/influx.go
+++ b/metrics/influx/influx.go
@@ -8,10 +8,10 @@ import (
 
 	influxdb "github.com/influxdata/influxdb/client/v2"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/generic"
-	"github.com/go-kit/kit/metrics/internal/lv"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/metrics/generic"
+	"github.com/codelingo/kit/metrics/internal/lv"
 )
 
 // Influx is a store for metrics that will be emitted to an Influx database.

--- a/metrics/influx/influx_test.go
+++ b/metrics/influx/influx_test.go
@@ -10,8 +10,8 @@ import (
 
 	influxdb "github.com/influxdata/influxdb/client/v2"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/metrics/teststat"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/metrics/teststat"
 )
 
 func TestCounter(t *testing.T) {

--- a/metrics/influxdb/influxdb.go
+++ b/metrics/influxdb/influxdb.go
@@ -10,7 +10,7 @@ import (
 	"github.com/codahale/hdrhistogram"
 	stdinflux "github.com/influxdata/influxdb/client/v2"
 
-	"github.com/go-kit/kit/metrics"
+	"github.com/codelingo/kit/metrics"
 )
 
 type counter struct {

--- a/metrics/influxdb/influxdb_test.go
+++ b/metrics/influxdb/influxdb_test.go
@@ -8,8 +8,8 @@ import (
 
 	stdinflux "github.com/influxdata/influxdb/client/v2"
 
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/influxdb"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/metrics/influxdb"
 )
 
 func TestCounter(t *testing.T) {

--- a/metrics/multi/multi.go
+++ b/metrics/multi/multi.go
@@ -4,7 +4,7 @@
 // transitioning from one system to another.
 package multi
 
-import "github.com/go-kit/kit/metrics"
+import "github.com/codelingo/kit/metrics"
 
 // Counter collects multiple individual counters and treats them as a unit.
 type Counter []metrics.Counter

--- a/metrics/multi/multi_test.go
+++ b/metrics/multi/multi_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/go-kit/kit/metrics"
+	"github.com/codelingo/kit/metrics"
 )
 
 func TestMultiCounter(t *testing.T) {

--- a/metrics/print_test.go
+++ b/metrics/print_test.go
@@ -6,9 +6,9 @@ import (
 
 	"math"
 
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/expvar"
-	"github.com/go-kit/kit/metrics/teststat"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/metrics/expvar"
+	"github.com/codelingo/kit/metrics/teststat"
 )
 
 func TestPrintDistribution(t *testing.T) {

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -7,8 +7,8 @@ package prometheus
 import (
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/internal/lv"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/metrics/internal/lv"
 )
 
 // Counter implements Counter, via a Prometheus CounterVec.

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -14,7 +14,7 @@ import (
 
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 
-	"github.com/go-kit/kit/metrics/teststat"
+	"github.com/codelingo/kit/metrics/teststat"
 )
 
 func TestCounter(t *testing.T) {

--- a/metrics/provider/circonus.go
+++ b/metrics/provider/circonus.go
@@ -1,8 +1,8 @@
 package provider
 
 import (
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/circonus"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/metrics/circonus"
 )
 
 type circonusProvider struct {

--- a/metrics/provider/discard.go
+++ b/metrics/provider/discard.go
@@ -1,8 +1,8 @@
 package provider
 
 import (
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/discard"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/metrics/discard"
 )
 
 type discardProvider struct{}

--- a/metrics/provider/dogstatsd.go
+++ b/metrics/provider/dogstatsd.go
@@ -1,8 +1,8 @@
 package provider
 
 import (
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/dogstatsd"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/metrics/dogstatsd"
 )
 
 type dogstatsdProvider struct {

--- a/metrics/provider/expvar.go
+++ b/metrics/provider/expvar.go
@@ -1,8 +1,8 @@
 package provider
 
 import (
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/expvar"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/metrics/expvar"
 )
 
 type expvarProvider struct{}

--- a/metrics/provider/graphite.go
+++ b/metrics/provider/graphite.go
@@ -1,8 +1,8 @@
 package provider
 
 import (
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/graphite"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/metrics/graphite"
 )
 
 type graphiteProvider struct {

--- a/metrics/provider/influx.go
+++ b/metrics/provider/influx.go
@@ -1,8 +1,8 @@
 package provider
 
 import (
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/influx"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/metrics/influx"
 )
 
 type influxProvider struct {

--- a/metrics/provider/prometheus.go
+++ b/metrics/provider/prometheus.go
@@ -3,8 +3,8 @@ package provider
 import (
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/prometheus"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/metrics/prometheus"
 )
 
 type prometheusProvider struct {

--- a/metrics/provider/provider.go
+++ b/metrics/provider/provider.go
@@ -24,7 +24,7 @@
 package provider
 
 import (
-	"github.com/go-kit/kit/metrics"
+	"github.com/codelingo/kit/metrics"
 )
 
 // Provider abstracts over constructors and lifecycle management functions for

--- a/metrics/provider/providers.go
+++ b/metrics/provider/providers.go
@@ -6,14 +6,14 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/discard"
-	"github.com/go-kit/kit/metrics/dogstatsd"
-	kitexp "github.com/go-kit/kit/metrics/expvar"
-	"github.com/go-kit/kit/metrics/graphite"
-	kitprom "github.com/go-kit/kit/metrics/prometheus"
-	"github.com/go-kit/kit/metrics/statsd"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/metrics/discard"
+	"github.com/codelingo/kit/metrics/dogstatsd"
+	kitexp "github.com/codelingo/kit/metrics/expvar"
+	"github.com/codelingo/kit/metrics/graphite"
+	kitprom "github.com/codelingo/kit/metrics/prometheus"
+	"github.com/codelingo/kit/metrics/statsd"
 )
 
 // Provider represents a union set of constructors and lifecycle management

--- a/metrics/provider/providers_test.go
+++ b/metrics/provider/providers_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 func TestGraphite(t *testing.T) {

--- a/metrics/provider/statsd.go
+++ b/metrics/provider/statsd.go
@@ -1,8 +1,8 @@
 package provider
 
 import (
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/statsd"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/metrics/statsd"
 )
 
 type statsdProvider struct {

--- a/metrics/statsd/emitter.go
+++ b/metrics/statsd/emitter.go
@@ -6,9 +6,9 @@ import (
 	"net"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/util/conn"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/util/conn"
 )
 
 // Emitter is a struct to manage connections and orchestrate the emission of

--- a/metrics/statsd/statsd.go
+++ b/metrics/statsd/statsd.go
@@ -13,11 +13,11 @@ import (
 	"io"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/internal/lv"
-	"github.com/go-kit/kit/metrics/internal/ratemap"
-	"github.com/go-kit/kit/util/conn"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/metrics/internal/lv"
+	"github.com/codelingo/kit/metrics/internal/ratemap"
+	"github.com/codelingo/kit/util/conn"
 )
 
 // Statsd receives metrics observations and forwards them to a StatsD server.

--- a/metrics/statsd/statsd_test.go
+++ b/metrics/statsd/statsd_test.go
@@ -3,8 +3,8 @@ package statsd
 import (
 	"testing"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/metrics/teststat"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/metrics/teststat"
 )
 
 func TestCounter(t *testing.T) {

--- a/metrics/teststat/buffers.go
+++ b/metrics/teststat/buffers.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/go-kit/kit/metrics/generic"
+	"github.com/codelingo/kit/metrics/generic"
 )
 
 // SumLines expects a regex whose first capture group can be parsed as a

--- a/metrics/teststat/populate.go
+++ b/metrics/teststat/populate.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"math/rand"
 
-	"github.com/go-kit/kit/metrics"
+	"github.com/codelingo/kit/metrics"
 )
 
 // PopulateNormalHistogram makes a series of normal random observations into the

--- a/metrics/teststat/teststat.go
+++ b/metrics/teststat/teststat.go
@@ -8,7 +8,7 @@ import (
 	"math/rand"
 	"strings"
 
-	"github.com/go-kit/kit/metrics"
+	"github.com/codelingo/kit/metrics"
 )
 
 // TestCounter puts some deltas through the counter, and then calls the value

--- a/metrics/timer_test.go
+++ b/metrics/timer_test.go
@@ -6,8 +6,8 @@ import (
 
 	"time"
 
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/generic"
+	"github.com/codelingo/kit/metrics"
+	"github.com/codelingo/kit/metrics/generic"
 )
 
 func TestTimerFast(t *testing.T) {

--- a/pubsub/rabbitmq/example/pubber/main.go
+++ b/pubsub/rabbitmq/example/pubber/main.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-kit/kit/pubsub/rabbitmq"
+	"github.com/codelingo/kit/pubsub/rabbitmq"
 )
 
 type arguments struct {

--- a/pubsub/rabbitmq/example/subber/main.go
+++ b/pubsub/rabbitmq/example/subber/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/go-kit/kit/pubsub/rabbitmq"
+	"github.com/codelingo/kit/pubsub/rabbitmq"
 )
 
 type arguments struct {

--- a/pubsub/rabbitmq/message.go
+++ b/pubsub/rabbitmq/message.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/streadway/amqp"
 
-	"github.com/go-kit/kit/pubsub"
+	"github.com/codelingo/kit/pubsub"
 )
 
 // Message is a minimal interface to describe payloads received by subscribers.

--- a/pubsub/rabbitmq/publisher.go
+++ b/pubsub/rabbitmq/publisher.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/streadway/amqp"
 
-	"github.com/go-kit/kit/pubsub"
+	"github.com/codelingo/kit/pubsub"
 )
 
 type publisher struct {

--- a/pubsub/rabbitmq/subscriber.go
+++ b/pubsub/rabbitmq/subscriber.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/streadway/amqp"
 
-	"github.com/go-kit/kit/pubsub"
+	"github.com/codelingo/kit/pubsub"
 )
 
 type subscriber struct {

--- a/ratelimit/token_bucket.go
+++ b/ratelimit/token_bucket.go
@@ -7,7 +7,7 @@ import (
 	"github.com/juju/ratelimit"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
+	"github.com/codelingo/kit/endpoint"
 )
 
 // ErrLimited is returned in the request path when the rate limiter is

--- a/ratelimit/token_bucket_test.go
+++ b/ratelimit/token_bucket_test.go
@@ -8,8 +8,8 @@ import (
 	jujuratelimit "github.com/juju/ratelimit"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/ratelimit"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/ratelimit"
 )
 
 func TestTokenBucketLimiter(t *testing.T) {

--- a/sd/cache/benchmark_test.go
+++ b/sd/cache/benchmark_test.go
@@ -4,8 +4,8 @@ import (
 	"io"
 	"testing"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/log"
 )
 
 func BenchmarkEndpoints(b *testing.B) {

--- a/sd/cache/cache.go
+++ b/sd/cache/cache.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/sd"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/sd"
 )
 
 // Cache collects the most recent set of endpoints from a service discovery

--- a/sd/cache/cache_test.go
+++ b/sd/cache/cache_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/log"
 )
 
 func TestCache(t *testing.T) {

--- a/sd/consul/client_test.go
+++ b/sd/consul/client_test.go
@@ -9,7 +9,7 @@ import (
 	stdconsul "github.com/hashicorp/consul/api"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
+	"github.com/codelingo/kit/endpoint"
 )
 
 func TestClientRegistration(t *testing.T) {

--- a/sd/consul/integration_test.go
+++ b/sd/consul/integration_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/log"
 	stdconsul "github.com/hashicorp/consul/api"
 )
 

--- a/sd/consul/registrar.go
+++ b/sd/consul/registrar.go
@@ -5,7 +5,7 @@ import (
 
 	stdconsul "github.com/hashicorp/consul/api"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 // Registrar registers service instance liveness information to Consul.

--- a/sd/consul/registrar_test.go
+++ b/sd/consul/registrar_test.go
@@ -5,7 +5,7 @@ import (
 
 	stdconsul "github.com/hashicorp/consul/api"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 func TestRegistrar(t *testing.T) {

--- a/sd/consul/subscriber.go
+++ b/sd/consul/subscriber.go
@@ -6,10 +6,10 @@ import (
 
 	consul "github.com/hashicorp/consul/api"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/sd"
-	"github.com/go-kit/kit/sd/cache"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/sd"
+	"github.com/codelingo/kit/sd/cache"
 )
 
 const defaultIndex = 0

--- a/sd/consul/subscriber_test.go
+++ b/sd/consul/subscriber_test.go
@@ -6,7 +6,7 @@ import (
 	consul "github.com/hashicorp/consul/api"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 var consulState = []*consul.ServiceEntry{

--- a/sd/dnssrv/subscriber.go
+++ b/sd/dnssrv/subscriber.go
@@ -5,10 +5,10 @@ import (
 	"net"
 	"time"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/sd"
-	"github.com/go-kit/kit/sd/cache"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/sd"
+	"github.com/codelingo/kit/sd/cache"
 )
 
 // Subscriber yields endpoints taken from the named DNS SRV record. The name is

--- a/sd/dnssrv/subscriber_test.go
+++ b/sd/dnssrv/subscriber_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/log"
 )
 
 func TestRefresh(t *testing.T) {

--- a/sd/etcd/example_test.go
+++ b/sd/etcd/example_test.go
@@ -6,9 +6,9 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/sd/lb"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/sd/lb"
 )
 
 func Example() {

--- a/sd/etcd/integration_test.go
+++ b/sd/etcd/integration_test.go
@@ -10,8 +10,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/log"
 )
 
 // Package sd/etcd provides a wrapper around the etcd key/value store. This

--- a/sd/etcd/registrar.go
+++ b/sd/etcd/registrar.go
@@ -3,7 +3,7 @@ package etcd
 import (
 	etcd "github.com/coreos/etcd/client"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 // Registrar registers service instance liveness information to etcd.

--- a/sd/etcd/registrar_test.go
+++ b/sd/etcd/registrar_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 // testClient is a basic implementation of Client

--- a/sd/etcd/subscriber.go
+++ b/sd/etcd/subscriber.go
@@ -1,10 +1,10 @@
 package etcd
 
 import (
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/sd"
-	"github.com/go-kit/kit/sd/cache"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/sd"
+	"github.com/codelingo/kit/sd/cache"
 )
 
 // Subscriber yield endpoints stored in a certain etcd keyspace. Any kind of

--- a/sd/etcd/subscriber_test.go
+++ b/sd/etcd/subscriber_test.go
@@ -7,8 +7,8 @@ import (
 
 	stdetcd "github.com/coreos/etcd/client"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/log"
 )
 
 var (

--- a/sd/factory.go
+++ b/sd/factory.go
@@ -3,7 +3,7 @@ package sd
 import (
 	"io"
 
-	"github.com/go-kit/kit/endpoint"
+	"github.com/codelingo/kit/endpoint"
 )
 
 // Factory is a function that converts an instance string (e.g. host:port) to a

--- a/sd/fixed_subscriber.go
+++ b/sd/fixed_subscriber.go
@@ -1,6 +1,6 @@
 package sd
 
-import "github.com/go-kit/kit/endpoint"
+import "github.com/codelingo/kit/endpoint"
 
 // FixedSubscriber yields a fixed set of services.
 type FixedSubscriber []endpoint.Endpoint

--- a/sd/lb/balancer.go
+++ b/sd/lb/balancer.go
@@ -3,7 +3,7 @@ package lb
 import (
 	"errors"
 
-	"github.com/go-kit/kit/endpoint"
+	"github.com/codelingo/kit/endpoint"
 )
 
 // Balancer yields endpoints according to some heuristic.

--- a/sd/lb/random.go
+++ b/sd/lb/random.go
@@ -3,8 +3,8 @@ package lb
 import (
 	"math/rand"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/sd"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/sd"
 )
 
 // NewRandom returns a load balancer that selects services randomly.

--- a/sd/lb/random_test.go
+++ b/sd/lb/random_test.go
@@ -4,8 +4,8 @@ import (
 	"math"
 	"testing"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/sd"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/sd"
 	"golang.org/x/net/context"
 )
 

--- a/sd/lb/retry.go
+++ b/sd/lb/retry.go
@@ -7,7 +7,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
+	"github.com/codelingo/kit/endpoint"
 )
 
 // Retry wraps a service load balancer and returns an endpoint oriented load

--- a/sd/lb/retry_test.go
+++ b/sd/lb/retry_test.go
@@ -7,9 +7,9 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/sd"
-	loadbalancer "github.com/go-kit/kit/sd/lb"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/sd"
+	loadbalancer "github.com/codelingo/kit/sd/lb"
 )
 
 func TestRetryMaxTotalFail(t *testing.T) {

--- a/sd/lb/round_robin.go
+++ b/sd/lb/round_robin.go
@@ -3,8 +3,8 @@ package lb
 import (
 	"sync/atomic"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/sd"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/sd"
 )
 
 // NewRoundRobin returns a load balancer that returns services in sequence.

--- a/sd/lb/round_robin_test.go
+++ b/sd/lb/round_robin_test.go
@@ -9,8 +9,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/sd"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/sd"
 )
 
 func TestRoundRobin(t *testing.T) {

--- a/sd/subscriber.go
+++ b/sd/subscriber.go
@@ -1,6 +1,6 @@
 package sd
 
-import "github.com/go-kit/kit/endpoint"
+import "github.com/codelingo/kit/endpoint"
 
 // Subscriber listens to a service discovery system and yields a set of
 // identical endpoints on demand. An error indicates a problem with connectivity

--- a/sd/zk/client.go
+++ b/sd/zk/client.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/samuel/go-zookeeper/zk"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 // DefaultACL is the default ACL to use for creating znodes.

--- a/sd/zk/client_test.go
+++ b/sd/zk/client_test.go
@@ -7,7 +7,7 @@ import (
 
 	stdzk "github.com/samuel/go-zookeeper/zk"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 func TestNewClient(t *testing.T) {

--- a/sd/zk/logwrapper.go
+++ b/sd/zk/logwrapper.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/samuel/go-zookeeper/zk"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 // wrapLogger wraps a Go kit logger so we can use it as the logging service for

--- a/sd/zk/registrar.go
+++ b/sd/zk/registrar.go
@@ -1,6 +1,6 @@
 package zk
 
-import "github.com/go-kit/kit/log"
+import "github.com/codelingo/kit/log"
 
 // Registrar registers service instance liveness information to ZooKeeper.
 type Registrar struct {

--- a/sd/zk/subscriber.go
+++ b/sd/zk/subscriber.go
@@ -3,10 +3,10 @@ package zk
 import (
 	"github.com/samuel/go-zookeeper/zk"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/sd"
-	"github.com/go-kit/kit/sd/cache"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/sd"
+	"github.com/codelingo/kit/sd/cache"
 )
 
 // Subscriber yield endpoints stored in a certain ZooKeeper path. Any kind of

--- a/sd/zk/util_test.go
+++ b/sd/zk/util_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/samuel/go-zookeeper/zk"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/sd"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/log"
+	"github.com/codelingo/kit/sd"
 )
 
 var (

--- a/tracing/opentracing/endpoint.go
+++ b/tracing/opentracing/endpoint.go
@@ -5,7 +5,7 @@ import (
 	otext "github.com/opentracing/opentracing-go/ext"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
+	"github.com/codelingo/kit/endpoint"
 )
 
 // TraceServer returns a Middleware that wraps the `next` Endpoint in an

--- a/tracing/opentracing/endpoint_test.go
+++ b/tracing/opentracing/endpoint_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
-	kitot "github.com/go-kit/kit/tracing/opentracing"
+	"github.com/codelingo/kit/endpoint"
+	kitot "github.com/codelingo/kit/tracing/opentracing"
 )
 
 func TestTraceServer(t *testing.T) {

--- a/tracing/opentracing/grpc.go
+++ b/tracing/opentracing/grpc.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 // ToGRPCRequest returns a grpc RequestFunc that injects an OpenTracing Span

--- a/tracing/opentracing/grpc_test.go
+++ b/tracing/opentracing/grpc_test.go
@@ -8,8 +8,8 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
 
-	"github.com/go-kit/kit/log"
-	kitot "github.com/go-kit/kit/tracing/opentracing"
+	"github.com/codelingo/kit/log"
+	kitot "github.com/codelingo/kit/tracing/opentracing"
 )
 
 func TestTraceGRPCRequestRoundtrip(t *testing.T) {

--- a/tracing/opentracing/http.go
+++ b/tracing/opentracing/http.go
@@ -9,8 +9,8 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/log"
-	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/codelingo/kit/log"
+	kithttp "github.com/codelingo/kit/transport/http"
 )
 
 // ToHTTPRequest returns an http RequestFunc that injects an OpenTracing Span

--- a/tracing/opentracing/http_test.go
+++ b/tracing/opentracing/http_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/log"
-	kitot "github.com/go-kit/kit/tracing/opentracing"
+	"github.com/codelingo/kit/log"
+	kitot "github.com/codelingo/kit/tracing/opentracing"
 )
 
 func TestTraceHTTPRequestRoundtrip(t *testing.T) {

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
-	"github.com/go-kit/kit/endpoint"
+	"github.com/codelingo/kit/endpoint"
 )
 
 // Client wraps a gRPC connection and provides a method that implements

--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -4,8 +4,8 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/log"
 )
 
 // Handler which should be called from the grpc binding of the service

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -7,7 +7,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/net/context/ctxhttp"
 
-	"github.com/go-kit/kit/endpoint"
+	"github.com/codelingo/kit/endpoint"
 )
 
 // Client wraps a URL and provides a method that implements endpoint.Endpoint.

--- a/transport/http/client_test.go
+++ b/transport/http/client_test.go
@@ -10,7 +10,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	httptransport "github.com/go-kit/kit/transport/http"
+	httptransport "github.com/codelingo/kit/transport/http"
 )
 
 type TestResponse struct {

--- a/transport/http/err_test.go
+++ b/transport/http/err_test.go
@@ -9,7 +9,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	httptransport "github.com/go-kit/kit/transport/http"
+	httptransport "github.com/codelingo/kit/transport/http"
 )
 
 func TestClientEndpointEncodeError(t *testing.T) {

--- a/transport/http/request_response_funcs_test.go
+++ b/transport/http/request_response_funcs_test.go
@@ -6,7 +6,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	httptransport "github.com/go-kit/kit/transport/http"
+	httptransport "github.com/codelingo/kit/transport/http"
 )
 
 func TestSetHeader(t *testing.T) {

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -5,8 +5,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/endpoint"
+	"github.com/codelingo/kit/log"
 )
 
 // Server wraps an endpoint and implements http.Handler.

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -9,7 +9,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	httptransport "github.com/go-kit/kit/transport/http"
+	httptransport "github.com/codelingo/kit/transport/http"
 )
 
 func TestServerBadDecode(t *testing.T) {

--- a/transport/httprp/README.md
+++ b/transport/httprp/README.md
@@ -15,8 +15,8 @@ import (
 	"net/http"
 	"net/url"
 
-	kithttp "github.com/go-kit/kit/transport/http"
-	kithttprp "github.com/go-kit/kit/transport/httprp"
+	kithttp "github.com/codelingo/kit/transport/http"
+	kithttprp "github.com/codelingo/kit/transport/httprp"
 	"github.com/gorilla/mux"
 	"golang.org/x/net/context"
 )

--- a/transport/httprp/server_test.go
+++ b/transport/httprp/server_test.go
@@ -9,7 +9,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	httptransport "github.com/go-kit/kit/transport/httprp"
+	httptransport "github.com/codelingo/kit/transport/httprp"
 )
 
 func TestServerHappyPathSingleServer(t *testing.T) {

--- a/util/conn/manager.go
+++ b/util/conn/manager.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 // Dialer imitates net.Dial. Dialer is assumed to yield connections that are

--- a/util/conn/manager_test.go
+++ b/util/conn/manager_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log"
+	"github.com/codelingo/kit/log"
 )
 
 func TestManager(t *testing.T) {


### PR DESCRIPTION
Replaced every single instance of "github.com/go-kit/kit" with "github.com/codelingo/kit". Only affects import statements.
